### PR TITLE
test that the html is the original html

### DIFF
--- a/test.js
+++ b/test.js
@@ -40,11 +40,10 @@ describe('injectMidContentAds()', () => {
   });
 
   describe('Article with Blacklist', () => {
-    document.body.innerHTML = injectMidContentAds(articleWithBlacklist);
-    const ads = document.querySelectorAll('.ad');
+    const html = injectMidContentAds(articleWithBlacklist);
 
     test('0 ads gets added', () => {
-      expect(ads.length).toBe(0);
+      expect(html).toBe(articleWithBlacklist.html);
     });
   });
 });


### PR DESCRIPTION
we had a dev test show up where the response for the blacklist ad was not valid article html, this should prevent that!